### PR TITLE
removes version message from async check (it was not nice dx).

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,11 @@ const {
   toStateful,
   toStateless
 } = require('@creuna/react-scripts');
+const semver = require('semver');
 
-const fetchLatestVersion = require('./source/fetch-latest-version');
+const configstore = require('./source/configstore');
 const currentVersion = require('./source/get-this-version');
+const fetchLatestVersion = require('./source/fetch-latest-version');
 const getConfig = require('./source/get-config');
 const lib = require('./source/get-components-from-library');
 const messages = require('./source/messages');
@@ -31,6 +33,8 @@ if (process.argv.includes('--version') || process.argv.includes('-v')) {
   messages.version(currentVersion);
   process.exit(0);
 }
+
+fetchLatestVersion();
 
 let shouldExit = false;
 
@@ -84,9 +88,12 @@ if (!command) {
   shouldExit = true;
 }
 
-fetchLatestVersion(currentVersion, (currentVersion, latestVersion) => {
+const latestVersion = configstore.get('latestVersion');
+if (latestVersion && semver.gt(latestVersion, currentVersion)) {
+  messages.emptyLine();
   messages.versionConflict(currentVersion, latestVersion);
-});
+  messages.emptyLine();
+}
 
 if (shouldExit) {
   process.exit(0);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@creuna/cli",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "Creuna command line tools",
   "main": "index.js",
   "scripts": {

--- a/source/fetch-latest-version.js
+++ b/source/fetch-latest-version.js
@@ -1,10 +1,9 @@
 const request = require('request');
-const semver = require('semver');
 
 const canConnect = require('./can-connect');
 const configstore = require('./configstore');
 
-async function fetchLatestVersion(currentVersion, onNewVersion) {
+async function fetchLatestVersion() {
   const canConnectToNPM = await canConnect('registry.npm.org');
 
   if (!canConnectToNPM) {
@@ -25,15 +24,7 @@ async function fetchLatestVersion(currentVersion, onNewVersion) {
       }
 
       try {
-        const latestVersion = JSON.parse(body)['dist-tags'].latest;
-        configstore.set('latestVersion', latestVersion);
-
-        if (
-          typeof onNewVersion === 'function' &&
-          semver.gt(latestVersion, currentVersion)
-        ) {
-          onNewVersion(currentVersion, latestVersion);
-        }
+        configstore.set('latestVersion', JSON.parse(body)['dist-tags'].latest);
       } catch (error) {
         // NOTE: Noop because we don't really care and there is no graceful fallback
       }


### PR DESCRIPTION
The checking is still async and done on every invocation, but the message printing is sync right before a possible process exit.